### PR TITLE
ci: add Codecov coverage and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,14 @@ jobs:
 
       - uses: astral-sh/setup-uv@v4
 
-      - name: Run tests
-        run: uv run pytest
+      - name: Run tests with coverage
+        run: uv run pytest --cov --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   secrets:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mnemolith
 
+[![CI](https://github.com/cbernet/mnemolith/actions/workflows/ci.yml/badge.svg)](https://github.com/cbernet/mnemolith/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/cbernet/mnemolith/branch/main/graph/badge.svg)](https://codecov.io/gh/cbernet/mnemolith)
+[![Security Review](https://github.com/cbernet/mnemolith/actions/workflows/security-review.yml/badge.svg)](https://github.com/cbernet/mnemolith/actions/workflows/security-review.yml)
+
 *Your thoughts, carved in stone.* Semantic search over an Obsidian vault using RAG, Qdrant, and MCP.
 
 ## Architecture


### PR DESCRIPTION
## Summary
- Add coverage collection (`--cov --cov-report=xml`) and Codecov upload to CI workflow
- Add CI, coverage, and security review badges to README

## Setup required
1. Enable repo on [codecov.io](https://codecov.io)
2. Add `CODECOV_TOKEN` to repo Actions secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)